### PR TITLE
chore: dockerize application

### DIFF
--- a/api/.dockerignore
+++ b/api/.dockerignore
@@ -1,0 +1,13 @@
+# The .dockerignore file excludes files from the container build process.
+#
+# https://docs.docker.com/engine/reference/builder/#dockerignore-file
+
+# Exclude locally vendored dependencies.
+vendor/
+
+# Exclude "build-time" ignore files.
+.dockerignore
+.gcloudignore
+
+# Exclude git history and configuration.
+.gitignore

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,7 @@
+FROM golang:1.22.3-alpine3.19
+WORKDIR /app
+COPY . .
+RUN go mod download
+EXPOSE 8080
+CMD ["go", "run", "main.go"]
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: "3.19"
+
+services:
+  api:
+    build:
+      context: ./api
+    ports:
+      - "8080:8080"
+    container_name: yifu-api
+


### PR DESCRIPTION
Uses docker to dockerize the API. I also added a `docker-compose.yml` for ease of use and later expansion.